### PR TITLE
Allow keyboard connect shortcut to be pressed to Connect

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@ Latest Builds: https://github.com/royrusso/elasticsearch-HQ
                                 <input type="text" placeholder="Enter http://domain:port" name="connectionURL"
                                        style="width: 220px;"
                                        id="connectionURL">
-                                <button class="btn btn-info" type="button" id="connectButton">Connect</button>
+                                <button class="btn btn-info" type="submit" id="connectButton">Connect</button>
                             </div>
                         </form>
 


### PR DESCRIPTION
Support pressing return/enter in the connect box instead of needing to click Connect by making the Connect button a form submit button.
