### PR TITLE
Remove unnecessary span class

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,7 +80,7 @@ Latest Builds: https://github.com/royrusso/elasticsearch-HQ
 <div class="container-fluid subnav">
 
     <div class="row-fluid">
-        <div class="pull-left span7" id="clusterHealth-loc" style="padding-bottom: 8px;">
+        <div class="pull-left" id="clusterHealth-loc" style="padding-bottom: 8px;">
         </div>
 
         <div id="toolbar" style="padding:0;margin:0;visibility: hidden;">


### PR DESCRIPTION
This fix prevents the health button from forcing the toolbar to wrap prematurely on smaller resolutions. 
