### PR TITLE
Fixed navigation bar to be responsive for resolutions lower than 979px w...

### DIFF
--- a/css/elastichq.css
+++ b/css/elastichq.css
@@ -3,6 +3,12 @@ body {
     padding-bottom: 40px;
 }
 
+@media (max-width: 979px){
+    body {
+        padding-top: 0;
+    }
+}
+
 .center-table {
     margin: 0 auto !important;
     float: none !important;


### PR DESCRIPTION
Updated CSS to reflect Bootstrap navigation bar changes required for the <body> on lower width resolution devices including ipad / tablets portrait view.  The current implementation contains a 40px _gap_ due to the "elastichq.css" override.

cool project = i am using for a project and will most likely be an active contributor!
