### PR TITLE
Sort indices on Cluster Status page in reverse name order

### DIFF
--- a/js/template/ClusterTemplates.js
+++ b/js/template/ClusterTemplates.js
@@ -157,4 +157,3 @@ clusterTemplate.HealthDescribe = [
     '</div>',
     '</div>'
 ].join("\n");
-


### PR DESCRIPTION
The unordered list of indices on the cluster bugs me.  This PR sorts them in reverse name order so the listing is predictable.
