### PR TITLE
npm install is needed before running grunt dev

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -10,7 +10,7 @@ DEVELOPMENT
 
 The development version will rewrite the index.html file in the root directory, using the index.html in the tpl directory, to point to un-minified and un-concatenated JS and CSS files. This is done to help in debugging JS errors or real-time modification of JS and CSS files.
 
-To build the development version, simply drop to console and type: **grunt dev**
+To build the development version, simply drop to console and type: **npm install && grunt dev**
 
 
 DISTRIBUTION
@@ -18,7 +18,7 @@ DISTRIBUTION
 
 The distribution will rewrite the index.html file in the root directory, using the index.html in the tpl directory, to point to minified and concatenated JS and CSS files.
 
-To build the distribution, simply drop to console and type: **grunt dist**
+To build the distribution, simply drop to console and type: **npm install && grunt dist**
 
 CHANGELOG
 --------------


### PR DESCRIPTION
Had to run `npm install` first. Maybe that's a Mac/homebrew thing.
