### PR TITLE
Upgraded vulnerable `moment` dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ElasticHQ
 =========
+[![Known Vulnerabilities](https://snyk.io/test/github/royrusso/elasticsearch-HQ/badge.svg)](https://snyk.io/test/github/royrusso/elasticsearch-HQ)
 
 Monitoring, Management, and Querying Web Interface for ElasticSearch instances and clusters.
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
   },
   "license": "Apache License",
   "dependencies": {
-    "moment": "~2.5.0"
+    "moment": "^2.11.2"
   }
 }


### PR DESCRIPTION
`elasticsearch-HQ` currently uses a vulnerable version of the `moment` dependency.
You can see details here (note this points to the latest commit hash at the time of this PR): https://snyk.io/test/github/royrusso/elasticsearch-HQ/fe18bc480840b84121606bc3c18a66a4a691ca12

This PR upgrades `moment` to the minimal version that isn't vulnerable. 
This is a minor upgrade, so should cause no disruption.

The project didn't see to have an existing set of tests, if it has some CI-based tests I would recommend adding `snyk test` to those tests, to help the project stay vulnerability free. Independent of that, I suggest you monitor the project by running [`snyk wizard`](https://snyk.io/docs/using-snyk/#wizard). Doing so will alert you when a new vulnerability that affects your dependencies is disclosed.

Lastly, to show the world you're doing a good job on security (and that they should care), I took the liberty of adding a badge stating you're free of known vulnerabilities. If you're gonna be awesome, no reason to hide it!
Note that the badge works off the latest master branch, so it'll show red until you actually merge this in.

Full disclosure: I'm a part of the Snyk team, just looking to spread some security goodness and awareness ;)
