### PR TITLE
The character encoding of the HTML document was not declared:fix #192

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@ Latest Builds: https://github.com/royrusso/elasticsearch-HQ
 <head>
     <title>Elastic HQ</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta charset='utf-8'>
 
     
 


### PR DESCRIPTION
fix [issue#192](https://github.com/royrusso/elasticsearch-HQ/issues/192)
