### PR TITLE
Fields is deprecated on elasticsearch 5.x.

### DIFF
--- a/js/model/query/QueryRequestModel.js
+++ b/js/model/query/QueryRequestModel.js
@@ -31,7 +31,7 @@ var QueryModel = Backbone.Model.extend({
                     }
                 }
             },
-            "fields" : null,
+            "_source" : false,
             "from":0,
             "size":10,
             "sort":[

--- a/js/model/query/QueryUtil.js
+++ b/js/model/query/QueryUtil.js
@@ -30,7 +30,7 @@ var QueryUtil =
                 "from":from,
                 "size":queryModel.get('queryObj').size,
                 "sort":queryModel.get('queryObj').sort,
-                "fields":queryModel.get('queryObj').fields,
+                "_source":queryModel.get('queryObj').fields,
                 "explain":true
             };
             //, "sort":[ {"_id":{"order":"asc" }}], "version":true, "fields":["_parent","_source"],"query":{"bool":{"must":[],"must_not":[],"should":[{"match_all":{}}]}} };

--- a/js/model/query/query.json
+++ b/js/model/query/query.json
@@ -23,7 +23,7 @@ http://localhost:9200/comicbook/_search
 }
 },
 "highlight" : {
-"fields" : {
+"stored_fields" : {
 "summary" : {}
 }
 }

--- a/js/view/document/DocumentListView.js
+++ b/js/view/document/DocumentListView.js
@@ -114,7 +114,6 @@ var DocumentListView = Backbone.View.extend({
                     result = item;
                     result._raw = JSON.stringify(item, undefined, 2);
 
-                    //jQuery.extend(result, item.fields); // merge _source items in to root level of object.
                     jQuery.extend(result, item._source); // merge _source items in to root level of object.
 
                     result.fields = undefined; // dont need this object nested in here.

--- a/js/view/document/DocumentListView.js
+++ b/js/view/document/DocumentListView.js
@@ -114,7 +114,8 @@ var DocumentListView = Backbone.View.extend({
                     result = item;
                     result._raw = JSON.stringify(item, undefined, 2);
 
-                    jQuery.extend(result, item.fields); // merge _source items in to root level of object.
+                    //jQuery.extend(result, item.fields); // merge _source items in to root level of object.
+                    jQuery.extend(result, item._source); // merge _source items in to root level of object.
 
                     result.fields = undefined; // dont need this object nested in here.
 


### PR DESCRIPTION
I used elasticsearch 5.x.

When I used Query menu of elasticsearch-HQ then fields is deprecated on elasticsearch 5.x.

[Rename fields parameter to stored_fields #7541](https://github.com/elastic/kibana/issues/7541)

I fixed field name to stored_fields. But It's not work.
I don't know why...

[So I read the document of elasticsearch 5.x document then found source filtering.](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-stored-fields.html)

I changed fields to _source.

It's working. 

I hope help to elasticHQ.