### PR TITLE
Correcting #412 - Indicies typo

### DIFF
--- a/ui/src/components/cluster-summary/cluster-summary.controller.js
+++ b/ui/src/components/cluster-summary/cluster-summary.controller.js
@@ -27,7 +27,7 @@ class clusterSummaryController {
                 value: numeral(this.summary.number_of_nodes).format(formatNum)
             },
             {
-                label: 'Indicies',
+                label: 'Indices',
                 value: numeral(this.summary.indices_count).format(formatNum)
             },
             {


### PR DESCRIPTION
Correcting typo of 'Indicies' in label on dashboard to 'Indices'.