### PR TITLE
Fixes #412 Indices typo

### DIFF
--- a/ui/src/components/cluster-summary/cluster-summary.controller.js
+++ b/ui/src/components/cluster-summary/cluster-summary.controller.js
@@ -27,7 +27,7 @@ class clusterSummaryController {
                 value: numeral(this.summary.number_of_nodes).format(formatNum)
             },
             {
-                label: 'Indicies',
+                label: 'Indices',
                 value: numeral(this.summary.indices_count).format(formatNum)
             },
             {


### PR DESCRIPTION
Resolving typo from incorrect 'Indicies' label to 'Indices'.