### PR TITLE
Correct for Openshift 3.11

### DIFF
--- a/openshift/README.md
+++ b/openshift/README.md
@@ -7,9 +7,9 @@ In this directory you'll find a ready to use [ElasticHQ](https://github.com/Elas
 1. Import all required images to your `logging` namespace. Just make sure that your cluster have access to the docker public registry:
 
 ```shell
-oc import-image nginx-114-rhel7 --from=registry.access.redhat.com/rhscl/nginx-114-rhel7 -n logging --confirm
-oc import-image elastic-hq-proxy --from=elastichq/elasticsearch-hq -n logging --confirm
-``` 
+oc import-image nginx-114-rhel7 --from=registry.access.redhat.com/rhscl/nginx-114-rhel7 -n openshift-logging --confirm
+oc import-image elastic-hq-proxy --from=elastichq/elasticsearch-hq -n openshift-logging --confirm
+```
 
 2. Clone this repository
 

--- a/openshift/elastic-hq-template.yaml
+++ b/openshift/elastic-hq-template.yaml
@@ -10,7 +10,7 @@ parameters:
   - name: LOGGING_NAMESPACE
     displayName: Logging namespace
     description: The name of where the logging ElasticSearch is deployed.
-    value: logging
+    value: openshift-logging
     required: true
   - name: ES_SECRET_NAME
     displayName: ElasticSearch Logging secret name

--- a/openshift/proxy/nginx.conf
+++ b/openshift/proxy/nginx.conf
@@ -38,7 +38,7 @@ http {
             error_log /var/opt/rh/rh-nginx114/log/nginx/proxy.log;
             
             proxy_set_header  X-Forwarded-For $remote_addr;
-            proxy_pass https://logging-es.logging.svc.cluster.local:9200;
+            proxy_pass https://logging-es.openshift-logging.svc.cluster.local:9200;
             proxy_ssl_verify  off;
             proxy_ssl_trusted_certificate /opt/app-root/src/elasticsearch/secret/admin-ca;
             proxy_ssl_certificate /opt/app-root/src/elasticsearch/secret/admin-cert;


### PR DESCRIPTION
Hi,
  in the openshift 3.11 ELK stack is installed in "openshift-logging" project instead "logging" project.
