### PR TITLE
Fix docker env vars

### DIFF
--- a/application.py
+++ b/application.py
@@ -13,9 +13,18 @@ default_debug = False
 default_enable_ssl = False
 default_ca_certs = None
 default_url = 'http://localhost:9200'
-is_gunicorn = "gunicorn" in os.environ.get("SERVER_SOFTWARE", "")
 
 application = create_app()
+
+# set default url, override with env for docker
+application.config['DEFAULT_URL'] = os.environ.get('HQ_DEFAULT_URL', default_url)
+application.config['ENABLE_SSL'] = os.environ.get('HQ_ENABLE_SSL', default_enable_ssl)
+application.config['CA_CERTS'] = os.environ.get('HQ_CA_CERTS', default_ca_certs)
+application.config['DEBUG'] = os.environ.get('HQ_DEBUG', default_debug)
+
+if os.environ.get('HQ_DEBUG')=='True':
+    config = find_config('logger_debug.json')
+    logging.config.dictConfig(config)
 
 if __name__ == '__main__':
     # Set up the command-line options
@@ -41,20 +50,7 @@ if __name__ == '__main__':
 
     options, _ = parser.parse_args()
 
-    # set default url, override with env for docker
-    application.config['DEFAULT_URL'] = os.environ.get('HQ_DEFAULT_URL', options.url)
-    application.config['ENABLE_SSL'] = os.environ.get('HQ_ENABLE_SSL', options.enable_ssl)
-    application.config['CA_CERTS'] = os.environ.get('HQ_CA_CERTS', options.ca_certs)
-
-    if is_gunicorn:
-        if options.debug:
-            config = find_config('logger_debug.json')
-            logging.config.dictConfig(config)
-
-        # we set reloader False so gunicorn doesn't call two instances of all the Flask init functions.
-        socketio.run(application, host=options.host, port=options.port, debug=options.debug, use_reloader=False)
-    else:
-        if options.debug:
-            config = find_config('logger_debug.json')
-            logging.config.dictConfig(config)
-        socketio.run(application, host=options.host, port=options.port, debug=options.debug)
+    if options.debug:
+        config = find_config('logger_debug.json')
+        logging.config.dictConfig(config)
+    socketio.run(application, host=options.host, port=options.port, debug=options.debug)

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -98,6 +98,7 @@ Environment Variables
     ``HQ_DEFAULT_URL``  ``http://localhost:9200``  Default URL displayed on the initial connection screen.
     ``HQ_ENABLE_SSL``   False                      If flag is passed, assumes ssl cert will be used.
     ``HQ_CA_CERTS``     /path/to/your/ca.crt       Path to your CA Certificate. Required if enable-ssl is passed.
+    ``HQ_DEBUG``        False                      If True, enables debug level on logging.
     ==================  =========================  ====================================================================
 
 


### PR DESCRIPTION
When docker container is used, the application is loaded via gunicorn. Since gunicorn imports an app as a python module, the code inside `if __name__ == '__main__':` is never executed. As a result the `application.config` doesn't get updated properly with the env vars passed via the docker cmd. I noticed this while investigating an ssl error on an ES cluster protected with Searchguard. The connection was failing with an "unknown_ca" (error snippet below - hostname has been anonymised) error on the ES side. The debug mode on logging is also affected by this issue so I've added one more env var in order to be able to enable/disable it.

Tested with:

**ElasticHQ Version:**
3.5.0

**Python version:**
Python 3.6.8 (default in docker container)

Error log snippet from the ES node:
```
[ERROR][c.f.s.s.h.n.SearchGuardSSLNettyHttpServerTransport] [elsnode.example.com] SSL Problem Received fatal alert: unknown_ca
javax.net.ssl.SSLException: Received fatal alert: unknown_ca
	at sun.security.ssl.Alerts.getSSLException(Alerts.java:208) ~[?:?]
	at sun.security.ssl.SSLEngineImpl.fatal(SSLEngineImpl.java:1647) ~[?:?]
	at sun.security.ssl.SSLEngineImpl.fatal(SSLEngineImpl.java:1615) ~[?:?]
	at sun.security.ssl.SSLEngineImpl.recvAlert(SSLEngineImpl.java:1781) ~[?:?]
	at sun.security.ssl.SSLEngineImpl.readRecord(SSLEngineImpl.java:1070) ~[?:?]
	at sun.security.ssl.SSLEngineImpl.readNetRecord(SSLEngineImpl.java:896) ~[?:?]
	at sun.security.ssl.SSLEngineImpl.unwrap(SSLEngineImpl.java:766) ~[?:?]
	at javax.net.ssl.SSLEngine.unwrap(SSLEngine.java:624) ~[?:1.8.0_212]
```