### PR TITLE
Develop

### DIFF
--- a/application.py
+++ b/application.py
@@ -13,6 +13,8 @@ default_debug = False
 default_enable_ssl = False
 default_ca_certs = None
 default_verify_certs = True
+default_client_key = None
+default_client_cert = None
 default_url = 'http://localhost:9200'
 is_gunicorn = "gunicorn" in os.environ.get("SERVER_SOFTWARE", "")
 
@@ -24,6 +26,8 @@ application.config['ENABLE_SSL'] = os.environ.get('HQ_ENABLE_SSL', default_enabl
 application.config['CA_CERTS'] = os.environ.get('HQ_CA_CERTS', default_ca_certs)
 application.config['HQ_VERIFY_CERTS'] = os.environ.get('HQ_VERIFY_CERTS', default_verify_certs)
 application.config['DEBUG'] = os.environ.get('HQ_DEBUG', default_debug)
+application.config['CLIENT_KEY'] = os.environ.get('CLIENT_KEY', default_client_key)
+application.config['CLIENT_CERT'] = os.environ.get('CLIENT_CERT', default_client_cert)
 
 if os.environ.get('HQ_DEBUG') == 'True':
     config = find_config('logger_debug.json')
@@ -51,6 +55,10 @@ if __name__ == '__main__':
                            'Path to CA file or directory [default %s]' % default_ca_certs)
     parser.add_option("-v", "--verify_certs", default=default_verify_certs,
                       help='Set to False when using self-signed certs.')
+    parser.add_option("-x", "--client_cert", default=default_client_cert,
+                      help='Set to path of the client cert file.')
+    parser.add_option("-X", "--client_key", default=default_client_key,
+                      help='Set to path of the client key file.')
 
     options, _ = parser.parse_args()
 
@@ -58,6 +66,8 @@ if __name__ == '__main__':
     application.config['ENABLE_SSL'] = os.environ.get('HQ_ENABLE_SSL', options.enable_ssl)
     application.config['CA_CERTS'] = os.environ.get('HQ_CA_CERTS', options.ca_certs)
     application.config['VERIFY_CERTS'] = os.environ.get('HQ_VERIFY_CERTS', options.verify_certs)
+    application.config['CLIENT_KEY'] = os.environ.get('CLIENT_KEY', options.client_key)
+    application.config['CLIENT_CERT'] = os.environ.get('CLIENT_CERT', options.client_cert)
 
     if is_gunicorn:
         if options.debug:

--- a/elastichq/api/clusters.py
+++ b/elastichq/api/clusters.py
@@ -114,13 +114,19 @@ class ClusterConnection(Resource):
             enable_ssl = current_app.config.get('ENABLE_SSL', False)
             ca_certs = current_app.config.get('CA_CERTS', None)
             verify_certs = current_app.config.get('VERIFY_CERTS', None)
+            client_key = current_app.config.get('CLIENT_KEY', None)
+            client_cert = current_app.config.get('CLIENT_CERT', None)
 
+            print(client_key)
+            print(client_cert)
             response = ConnectionService().create_connection(ip=params['ip'], port=params.get('port', "9200"),
                                                              scheme=scheme, username=params.get('username', None),
                                                              password=params.get('password', None),
                                                              fail_on_exception=True,
                                                              enable_ssl=enable_ssl, ca_certs=ca_certs,
-                                                             verify_certs=verify_certs)
+                                                             verify_certs=verify_certs,
+                                                             client_key=client_key,
+                                                             client_cert=client_cert)
 
             schema = ClusterDTO(many=False)
             result = schema.dump(response)

--- a/elastichq/service/ConnectionService.py
+++ b/elastichq/service/ConnectionService.py
@@ -36,9 +36,11 @@ class ConnectionService:
             return False
 
     def create_connection(self, ip, port, scheme='http', username=None, password=None, fail_on_exception=False,
-                          enable_ssl=False, ca_certs=None, verify_certs=True):
+                          enable_ssl=False, ca_certs=None, verify_certs=True, client_cert=None, client_key=None):
         """
         Creates a connection with a cluster and place the connection inside of a connection pool, using the cluster_name as an alias.
+        :param client_cert:
+        :param client_key:
         :param verify_certs:
         :param ip:
         :param port: 
@@ -60,17 +62,19 @@ class ConnectionService:
                 is_basic_auth = True
                 password = urllib.parse.unquote(password)
 
+            client_cert_credentials = None if client_cert is None or client_key is None else (client_cert, client_key)
+
             # determine version first
             if is_basic_auth is True:
                 if enable_ssl:
                     response = requests.get(scheme + "://" + ip + ":" + port, auth=(username, password),
-                                            timeout=REQUEST_TIMEOUT, verify=ca_certs)
+                                            timeout=REQUEST_TIMEOUT, verify=ca_certs, cert=client_cert_credentials)
                 else:
                     response = requests.get(scheme + "://" + ip + ":" + port, auth=(username, password),
                                             timeout=REQUEST_TIMEOUT)
             else:
                 if enable_ssl:
-                    response = requests.get(scheme + "://" + ip + ":" + port, timeout=REQUEST_TIMEOUT, verify=ca_certs)
+                    response = requests.get(scheme + "://" + ip + ":" + port, timeout=REQUEST_TIMEOUT, verify=ca_certs, cert=client_cert_credentials)
                 else:
                     response = requests.get(scheme + "://" + ip + ":" + port, timeout=REQUEST_TIMEOUT)
 
@@ -85,7 +89,8 @@ class ConnectionService:
                 if enable_ssl:
                     conn = Elasticsearch(hosts=[scheme + "://" + ip + ":" + port], maxsize=5,
                                          use_ssl=True, verify_certs=verify_certs, ca_certs=ca_certs,
-                                         version=content.get('version').get('number'), http_auth=(username, password))
+                                         version=content.get('version').get('number'), http_auth=(username, password),
+                                         client_cert=client_cert, client_key=client_key)
                 else:
                     conn = Elasticsearch(hosts=[scheme + "://" + ip + ":" + port], maxsize=5,
                                          version=content.get('version').get('number'), http_auth=(username, password))
@@ -94,7 +99,8 @@ class ConnectionService:
                 if enable_ssl:
                     conn = Elasticsearch(hosts=[scheme + "://" + ip + ":" + port], maxsize=5,
                                          use_ssl=True, verify_certs=verify_certs, ca_certs=ca_certs,
-                                         version=content.get('version').get('number'))
+                                         version=content.get('version').get('number'),
+                                         client_cert=client_cert, client_key=client_key)
                 else:
                     conn = Elasticsearch(hosts=[scheme + "://" + ip + ":" + port], maxsize=5,
                                          version=content.get('version').get('number'))


### PR DESCRIPTION
# PR Details
The suggested change adds support for client authentication against ElasticSearch

## Description
**X-Pack** or **SearchGuard** can be configured to demand client certificate for authentication of ElasticSearch API clients.
The suggested change would be to support two new *application.py* command-line parameters, *--client_cert* and *--client-key*. They are file paths of public key certificate (PEM) and key files.
The change is trivial as the underlying implementation (vendor/ElasticSearch) already supports it, the parameters simply need to be passed downstream.
