### PR TITLE
Fixes #527: Allow suburl to map the application

### DIFF
--- a/ui/src/containers/cluster-nodes/cluster-nodes.controller.js
+++ b/ui/src/containers/cluster-nodes/cluster-nodes.controller.js
@@ -14,20 +14,25 @@ class clusterNodesController {
         this.clusterName = $stateParams.clusterName;
 
         // Try to get URL
-        //  even if path is being forwared by a Apache / Nginx conf.
+        //  even if path is being forwarded by a Apache / Nginx conf.
         //  i.e. http://my_site.com/my/custom/path is the root of the python app
         console.log('---- window.location', window.location)
-        let baseUrl = window.location.href.split('/#!')[0];
 
-        if (/\:8080/.test(baseUrl)) baseUrl = 'http://localhost:5000';
+        let url = `${window.location.protocol}//${window.location.host}`;
+        let baseUrl = window.location.pathname
+        // console.log('---- baseUrl: ', baseUrl)
+
+        if (/\:8080/.test(url)) {
+            url = 'http://localhost:5000';
+        }
 
         // Websockets do not work with relative paths, so get absolute and append the WS portion
         //  upgrade from HTTP to WS should be automatic
-        // baseUrl = baseUrl += `/ws/nodes/${this.clusterName}/nodes`;
-        baseUrl = baseUrl += `/ws`;
-        // console.log('---- baseUrl: ', baseUrl)
+        // url = url += `/ws/nodes/${this.clusterName}/nodes`;
+        url = url += `/ws`;
+        // console.log('---- url: ', url)
 
-        this.socket = io(baseUrl);
+        this.socket = io(url, { path: baseUrl+"socket.io" });
         this.socket.on('connect', () => {
             this.connected = true;
             this.socket.emit('join', {"room_name": this.clusterName + "::nodes"});


### PR DESCRIPTION
# Instructions

Please try and perform pull requests against the ``develop`` branch. 

Merging against the master branch causes a new release to be deployed, and I'd like to avoid that on every PR.  

# PR Details

Fixed an issue where the base url was ignored when calling the websocket api of the metrics page when accessing through a reverse proxy

## Description

As already pointed out in issue #527, when accessing through a reverse proxy, when a url with a base path is used, the base path is ignored and the metrics page is not properly loaded. (e.g. https://www.example.com/elastichq)

The reason is that the subpath of the url entered when establishing a connection to the socket.io is recognized as a namespace. In order to use the subpath of the reverse proxy as it is, a custom path must be set separately.
For example, if you enter url as the following, the socket will connect to the `elastichq` namespace.
```
this.socket = io("https://www.example.com/elastichq");
```

To include elastichq in the custom path as intended, it should be modified as follows.
```
this.socket = io(url, { path: "https://www.example.com"+"elastichq/socket.io" });
```

I tested through the nginx proxy environment of kubernetes, and it worked fine in my case. There seems to be a lot of similar questions, so I send a pull request with the modified version. If there is anything wrong, please comment. I hope it helps.


## Related Issue

https://github.com/ElasticHQ/elasticsearch-HQ/issues/527